### PR TITLE
Implement an OAuth client for the Zoom API

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Or install it yourself as:
 
 ## Usage
 
+The Zoom API uses OAuth and JWT to [Authenticate](https://marketplace.zoom.us/docs/api-reference/Authentication) API request. By defaut, a JWT client will be used.
+
 ```ruby
 require 'zoom'
 
@@ -28,6 +30,18 @@ end
 
 zoom_client = Zoom.new
 
+```
+
+To create an OAuth client, create the client directly
+
+```ruby
+require 'zoom'
+zoom_client = Zoom::Clients::OAuth.new(:access_token => 'xxx', :timeout => 15)
+```
+
+With the client, access the API
+
+```ruby
 user_list = zoom_client.user_list
 user_list['users'].each do |user|
   user_id = user['id']

--- a/lib/zoom.rb
+++ b/lib/zoom.rb
@@ -26,7 +26,7 @@ module Zoom
 
     def new
       @configuration ||= Configuration.new
-      Zoom::Client.new(
+      Zoom::Clients::JWT.new(
         api_key: @configuration.api_key,
         api_secret: @configuration.api_secret,
         timeout: @configuration.timeout
@@ -40,10 +40,11 @@ module Zoom
   end
 
   class Configuration
-    attr_accessor :api_key, :api_secret, :timeout
+    attr_accessor :api_key, :api_secret, :timeout, :access_token
 
     def initialize
       @api_key = @api_secret = 'xxx'
+      @access_token = nil
       @timeout = 15
     end
   end

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'httparty'
-require 'json'
-require 'jwt'
 
 module Zoom
   class Client
@@ -23,12 +21,6 @@ module Zoom
     headers 'Accept' => 'application/json'
     headers 'Content-Type' => 'application/json'
 
-    def initialize(config)
-      Utils.require_params(%i[api_key api_secret], config)
-      config.each { |k, v| instance_variable_set("@#{k}", v) }
-      self.class.default_timeout(@timeout)
-    end
-
     def request_headers
       {
         'Accept' => 'application/json',
@@ -36,9 +28,8 @@ module Zoom
         'Authorization' => "Bearer #{access_token}"
       }
     end
-
-    def access_token
-      JWT.encode({ iss: @api_key, exp: Time.now.to_i + @timeout }, @api_secret, 'HS256', { typ: 'JWT' })
-    end
   end
 end
+
+require 'zoom/clients/jwt'
+require 'zoom/clients/oauth'

--- a/lib/zoom/clients/jwt.rb
+++ b/lib/zoom/clients/jwt.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'jwt'
+
+module Zoom
+  module Clients
+    class JWT < Zoom::Client
+
+      def initialize(config)
+        Utils.require_params(%i[api_key api_secret], config)
+        config.each { |k, v| instance_variable_set("@#{k}", v) }
+        self.class.default_timeout(@timeout)
+      end
+
+      def access_token
+        ::JWT.encode({ iss: @api_key, exp: Time.now.to_i + @timeout }, @api_secret, 'HS256', { typ: 'JWT' })
+      end
+
+    end
+  end
+end
+
+

--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Zoom
+  module Clients
+    class OAuth < Zoom::Client
+      def initialize(config)
+        Utils.require_params(%i[access_token], config)
+        config.each { |k, v| instance_variable_set("@#{k}", v) }
+        self.class.default_timeout(@timeout)
+      end
+
+      def access_token
+        @access_token
+      end
+    end
+
+  end
+
+end
+
+

--- a/spec/lib/zoom/actions/webinar/create_spec.rb
+++ b/spec/lib/zoom/actions/webinar/create_spec.rb
@@ -3,51 +3,56 @@
 require 'spec_helper'
 
 RSpec.describe Zoom::Actions::Webinar do
-  let(:zc) { zoom_client }
-  let(:args) { { host_id: 'test_user_id' } }
 
-  describe '#webinar_create' do
-    context 'with a valid response' do
-      before :each do
-        stub_request(
-          :post,
-          zoom_url("/users/#{args[:host_id]}/webinars")
-        ).to_return(body: json_response('webinar', 'create'),
-                    headers: { 'Content-Type' => 'application/json' })
-      end
+  [:jwt_client, :oauth_client].each do |client|
+    describe "#{client}" do
+      let(:zc) { send(client) }
+      let(:args) { { host_id: 'test_user_id' } }
 
-      it "requires a 'host_id' argument" do
-        expect { zc.webinar_create(filter_key(args, :host_id)) }.to raise_error(Zoom::ParameterMissing, [:host_id].to_s)
-      end
+      describe '#webinar_create' do
+        context 'with a valid response' do
+          before :each do
+            stub_request(
+              :post,
+              zoom_url("/users/#{args[:host_id]}/webinars")
+            ).to_return(body: json_response('webinar', 'create'),
+                        headers: { 'Content-Type' => 'application/json' })
+          end
 
-      it 'returns a hash' do
-        expect(zc.webinar_create(args)).to be_kind_of(Hash)
-      end
+          it "requires a 'host_id' argument" do
+            expect { zc.webinar_create(filter_key(args, :host_id)) }.to raise_error(Zoom::ParameterMissing, [:host_id].to_s)
+          end
 
-      it 'returns the setted params' do
-        res = zc.webinar_create(args)
-        expect(res['host_id']).to eq(args[:host_id])
-      end
+          it 'returns a hash' do
+            expect(zc.webinar_create(args)).to be_kind_of(Hash)
+          end
 
-      it "returns 'start_url' and 'join_url'" do
-        res = zc.webinar_create(args)
+          it 'returns the setted params' do
+            res = zc.webinar_create(args)
+            expect(res['host_id']).to eq(args[:host_id])
+          end
 
-        expect(res['start_url']).to_not be_nil
-        expect(res['join_url']).to_not be_nil
-      end
-    end
+          it "returns 'start_url' and 'join_url'" do
+            res = zc.webinar_create(args)
 
-    context 'with a 4xx response' do
-      before :each do
-        stub_request(
-          :post,
-          zoom_url("/users/#{args[:host_id]}/webinars")
-        ).to_return(body: json_response('error', 'validation'),
-                    headers: { 'Content-Type' => 'application/json' })
-      end
+            expect(res['start_url']).to_not be_nil
+            expect(res['join_url']).to_not be_nil
+          end
+        end
 
-      it 'raises Zoom::Error exception' do
-        expect { zc.webinar_create(args) }.to raise_error(Zoom::Error)
+        context 'with a 4xx response' do
+          before :each do
+            stub_request(
+              :post,
+              zoom_url("/users/#{args[:host_id]}/webinars")
+            ).to_return(body: json_response('error', 'validation'),
+                        headers: { 'Content-Type' => 'application/json' })
+          end
+
+          it 'raises Zoom::Error exception' do
+            expect { zc.webinar_create(args) }.to raise_error(Zoom::Error)
+          end
+        end
       end
     end
   end

--- a/spec/lib/zoom/client_spec.rb
+++ b/spec/lib/zoom/client_spec.rb
@@ -2,11 +2,12 @@
 
 require 'spec_helper'
 
-xdescribe Zoom::Client do
+describe Zoom::Client do
 
-  xdescribe 'default attributes' do
+  describe 'default attributes' do
     it 'must include httparty methods' do
       expect(Zoom::Client).to include(HTTParty)
+      expect(Zoom::Clients::JWT).to include(HTTParty)
     end
 
     it 'must have the base url set to Zoom API endpoint' do
@@ -19,7 +20,7 @@ xdescribe Zoom::Client do
         config.api_secret = 'xxx'
       end
       Zoom.new
-      expect(Zoom::Client.default_options[:timeout]).to eq(15)
+      expect(Zoom::Clients::JWT.default_options[:timeout]).to eq(15)
     end
 
     it 'must get the timeout from the configuration' do
@@ -29,17 +30,47 @@ xdescribe Zoom::Client do
         config.timeout = 20
       end
       Zoom.new
-      expect(Zoom::Client.default_options[:timeout]).to eq(20)
+      expect(Zoom::Clients::JWT.default_options[:timeout]).to eq(20)
     end
   end
 
-  xdescribe 'constructor' do
+  describe 'JWT client' do
+    let(:client) {
+      Zoom::Clients::JWT.new(api_key: 'xxx', api_secret: 'xxx', timeout: 15)
+    }
     it 'requires api_key and api_secret for a new instance' do
-      expect { Zoom::Client.new(api_key: 'xxx') }.to raise_error(ArgumentError)
+      expect { Zoom::Clients::JWT.new(api_key: 'xxx') }.to raise_error(ArgumentError)
+      expect { Zoom::Clients::JWT.new(api_key: 'xxx', api_secret: 'xxx') }.to raise_error(ArgumentError)
     end
 
     it 'creates instance of Zoom::Client if api_key and api_secret is provided' do
-      expect(Zoom::Client.new(api_key: 'xxx', api_secret: 'xxx', timeout: 15)).to be_an_instance_of(Zoom::Client)
+      expect(client).to be_kind_of(Zoom::Client)
+    end
+
+    it 'has the bearer token in the auth header' do
+      fake_token = 'NotTheRealToken'
+      allow(client).to receive(:access_token) {fake_token}
+      expect(client.request_headers['Authorization']).to eq("Bearer #{fake_token}")
+    end
+
+  end
+
+  describe "oauth client" do
+    let(:access_token) {'xxx'}
+    let(:client) {
+      Zoom::Clients::OAuth.new(access_token: access_token, timeout: 30)
+    }
+    it 'requires an access token' do
+      expect { Zoom::Clients::JWT.new(timeout: 30) }.to raise_error(ArgumentError)
+      expect { Zoom::Clients::JWT.new(access_token: access_token) }.to raise_error(ArgumentError)
+    end
+
+    it 'creates instance of Zoom::Client if api_key and api_secret is provided' do
+      expect(client).to be_kind_of(Zoom::Client)
+    end
+
+    it 'has the bearer token in the auth header' do
+      expect(client.request_headers['Authorization']).to eq("Bearer #{access_token}")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,16 @@ def zoom_url(url)
   /https:\/\/api.zoom.us\/v2#{url}.*/
 end
 
-def zoom_client
+def jwt_client
   Zoom.new
+end
+
+def oauth_client
+  Zoom::Clients::OAuth.new(access_token: 'xxx', timeout: 15)
+end
+
+def zoom_client
+  jwt_client
 end
 
 def filter_key(hash, key)


### PR DESCRIPTION
The Zoom API allows both JWT and OAuth access to the API.  This feature adds an
OAuth client to compliment the existing JWT client.  By default, the JWT client
will be used with creating a client with Zoom.new.   To create an OAuth client,
the client is created directly (Zoom::Clients::OAuth.new).

This commit keeps backwards compatibility with clients created using Zoom.new,
but applications that used the client directly, Zoom::Client.new will be affected.

Changes:
- Make Zoom::Client a base class
- Add Zoom::Clients::JWT and Zoom::Clients::OAuth
- Update readme with client examples
- Move JWT specific code out of Zoom::Client and into Zoom::Clients::JWT
- Add OAuth client specific tests
- Modify one existing spec to use both types of clients
- Re-Enable the zoom/client_spec.rb tests