### PR TITLE
Implement get_webinar_registrant

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -104,6 +104,12 @@ module Zoom
         params.require(:id)
         Utils.parse_response self.class.get("/past_webinars/#{params[:id]}/instances", headers: request_headers)
       end
+
+      def webinar_registrant_get(*args)
+        params = Zoom::Params.new(Utils.extract_options!(args))
+        params.require(:webinar_id, :id).permit(:occurrence_id)
+        Utils.parse_response self.class.get("/webinars/#{params[:webinar_id]}/registrants/#{params[:id]}", query: params.except(:webinar_id, :id), headers: request_headers)
+      end
     end
   end
 end

--- a/spec/fixtures/webinar/registrant/get.json
+++ b/spec/fixtures/webinar/registrant/get.json
@@ -1,0 +1,25 @@
+{
+  "id": "FAKE",
+  "first_name": "Bobby",
+  "last_name": "Tables",
+  "email": "bobby_tables@example.org",
+  "address": "",
+  "city": "",
+  "country": "",
+  "zip": "",
+  "state": "",
+  "phone": "",
+  "industry": "",
+  "org": "",
+  "job_title": "",
+  "purchasing_time_frame": "",
+  "role_in_purchase_process": "",
+  "no_of_employees": "",
+  "comments": "",
+  "custom_questions": [
+
+  ],
+  "status": "approved",
+  "create_time": "2019-06-26T10:45:56Z",
+  "join_url": "https://zoom.us/w/FAKE"
+}

--- a/spec/lib/zoom/actions/webinar/registrants/get_spec.rb
+++ b/spec/lib/zoom/actions/webinar/registrants/get_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zoom::Actions::Webinar do
+  let(:zc) { zoom_client }
+  let(:args) { { webinar_id: 'webinar_id', id: 'registrant_id' } }
+
+  describe '#webinar_registrant_get' do
+    context 'with a valid response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/webinars/#{args[:webinar_id]}/registrants/#{args[:id]}")
+        ).to_return(body: json_response('webinar', 'registrant', 'get'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it "requires a 'webinar_id' argument" do
+        expect { zc.webinar_registrant_get(filter_key(args, :webinar_id)) }.to raise_error(Zoom::ParameterMissing, [:webinar_id].to_s)
+      end
+      it "requires a 'id' argument" do
+        expect { zc.webinar_registrant_get(filter_key(args, :id)) }.to raise_error(Zoom::ParameterMissing, [:id].to_s)
+      end
+      it "allows occurrence_id" do
+        expect { zc.webinar_registrant_get(args.merge(:occurrence_id => '5')) }.not_to raise_error
+      end
+
+      it 'returns an Hash' do
+        expect(zc.webinar_registrant_get(args)).to be_kind_of(Hash)
+      end
+    end
+
+    context 'with a 4xx response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/webinars/#{args[:webinar_id]}/registrants/#{args[:id]}")
+        ).to_return(status: 404,
+                    body: json_response('error', 'validation'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises Zoom::Error exception' do
+        expect { zc.webinar_registrant_get(args) }.to raise_error(Zoom::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
From: https://marketplace.zoom.us/docs/api-reference/zoom-api/webinars/webinarregistrantget

Endpoint: GET /webinars/{webinarId}/registrants/{registrantId}