### PR TITLE
Bring back to_json for roles actions

### DIFF
--- a/lib/zoom/actions/roles.rb
+++ b/lib/zoom/actions/roles.rb
@@ -9,9 +9,9 @@ module Zoom
       end
 
       def roles_create(*args)
-        params = Zoom::Params.new(Utils.extract_options!(args))
-        params.require(:name).permit(%i[description privileges])
-        Utils.parse_response self.class.post("/roles", body: params, headers: request_headers)
+        options = Params.new(Utils.extract_options!(args))
+        options.require(:name).permit(%i[description privileges])
+        Utils.parse_response self.class.post("/roles", body: options.to_json, headers: request_headers)
       end
 
       def roles_members(*args)
@@ -21,9 +21,9 @@ module Zoom
       end
 
       def roles_assign(*args)
-        params = Zoom::Params.new(Utils.extract_options!(args))
-        params.require(%i[role_id members])
-        Utils.parse_response self.class.post("/roles/#{params[:role_id]}/members", body: params.except(:role_id), headers: request_headers)
+        options = Params.new(Utils.extract_options!(args))
+        options.require(%i[role_id members])
+        Utils.parse_response self.class.post("/roles/#{options[:role_id]}/members", body: options.except(:role_id).to_json, headers: request_headers)
       end
 
       def roles_unassign(*args)

--- a/lib/zoom/actions/roles.rb
+++ b/lib/zoom/actions/roles.rb
@@ -9,9 +9,9 @@ module Zoom
       end
 
       def roles_create(*args)
-        options = Params.new(Utils.extract_options!(args))
-        options.require(:name).permit(%i[description privileges])
-        Utils.parse_response self.class.post("/roles", body: options.to_json, headers: request_headers)
+        params = Zoom::Params.new(Utils.extract_options!(args))
+        params.require(:name).permit(%i[description privileges])
+        Utils.parse_response self.class.post("/roles", body: params.to_json, headers: request_headers)
       end
 
       def roles_members(*args)
@@ -21,9 +21,9 @@ module Zoom
       end
 
       def roles_assign(*args)
-        options = Params.new(Utils.extract_options!(args))
-        options.require(%i[role_id members])
-        Utils.parse_response self.class.post("/roles/#{options[:role_id]}/members", body: options.except(:role_id).to_json, headers: request_headers)
+        params = Zoom::Params.new(Utils.extract_options!(args))
+        params.require(%i[role_id members])
+        Utils.parse_response self.class.post("/roles/#{params[:role_id]}/members", body: params.except(:role_id).to_json, headers: request_headers)
       end
 
       def roles_unassign(*args)


### PR DESCRIPTION
Otherwise we get
```
Request Body should be a valid JSON object.
```