### PR TITLE
API for updating questions for registrering a meeting

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -71,6 +71,13 @@ module Zoom
         Utils.parse_response self.class.post("/meetings/#{options[:meeting_id]}/registrants", body: options.except(:meeting_id).to_json, headers: request_headers)
       end
 
+      # Register for a meeting.
+      def meeting_registrant_questions(*args)
+        options = Zoom::Params.new(Utils.extract_options!(args))
+        options.require(%i[meeting_id])
+        Utils.parse_response self.class.patch("/meetings/#{options[:meeting_id]}/registrants/questions", body: options.except(:meeting_id).to_json, headers: request_headers)
+      end
+
       # Retrieve ended meeting details
       def past_meeting_details(*args)
         options = Zoom::Params.new(Utils.extract_options!(args))


### PR DESCRIPTION
Added support for the API [Meeting Registrants Questions Update](https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetingregistrantquestionupdate).