### PR TITLE
Fix the intermittent failure for the default timeout test client_spec:17

### DIFF
--- a/spec/lib/zoom/client_spec.rb
+++ b/spec/lib/zoom/client_spec.rb
@@ -21,6 +21,7 @@ describe Zoom::Client do
       end
       Zoom.new
       expect(Zoom::Client::JWT.default_options[:timeout]).to eq(15)
+      Zoom.configuration = nil
     end
 
     it 'must get the timeout from the configuration' do
@@ -31,6 +32,7 @@ describe Zoom::Client do
       end
       Zoom.new
       expect(Zoom::Client::JWT.default_options[:timeout]).to eq(20)
+      Zoom.configuration = nil
     end
   end
 


### PR DESCRIPTION
I found that the test to check the default timeout is failing intermittently when it runs after the next test to set the timeout. 

Fixed it by making the configuration nil at tne end of each test.