### PR TITLE
Better: raise AuthentificationError on code 124

### DIFF
--- a/lib/zoom/error.rb
+++ b/lib/zoom/error.rb
@@ -7,4 +7,5 @@ module Zoom
   class ParameterMissing < StandardError; end
   class ParameterNotPermitted < StandardError; end
   class ParameterValueNotPermitted < StandardError; end
+  class AuthenticationError < StandardError; end
 end

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -12,14 +12,18 @@ module Zoom
       end
 
       def raise_if_error!(response)
-        if response&.[]('code') && response['code'] >= 300
-          error_hash = { base: response['message']}
-          raise Error, error_hash unless response['errors']
-          error_hash[response['message']] = response['errors']
-          raise Error, error_hash
-        else
-          response
-        end
+        return response unless response.key?('code')
+
+        code = response['code']
+
+        raise AuthenticationError, build_error(response) if code == 124
+        raise Error, build_error(response) if code >= 300
+      end
+
+      def build_error(response)
+        error_hash = { base: response['message']}
+        error_hash[response['message']] = response['errors'] if response['errors']
+        error_hash
       end
 
       def parse_response(http_response)

--- a/lib/zoom/utils.rb
+++ b/lib/zoom/utils.rb
@@ -12,7 +12,7 @@ module Zoom
       end
 
       def raise_if_error!(response)
-        return response unless response.key?('code')
+        return response unless response&.key?('code')
 
         code = response['code']
 

--- a/spec/lib/zoom/utils_spec.rb
+++ b/spec/lib/zoom/utils_spec.rb
@@ -2,21 +2,26 @@
 
 require 'spec_helper'
 
-xdescribe Zoom::Utils do
+describe Zoom::Utils do
 
   before(:all) do
     class Utils < Zoom::Utils; end
   end
 
-  xdescribe '#argument_error' do
+  describe '#argument_error' do
     it 'raises ArgumentError' do
       expect(Utils.argument_error('foo')).to be_instance_of(ArgumentError)
     end
   end
 
-  xdescribe '#raise_if_error!' do
-    it 'raises Zoom::Error if error is present' do
-      response = { 'error' => { 'message' => 'lol error' } }
+  describe '#raise_if_error!' do
+    it 'raises Zoom::AuthenticationError if error is present and code = 124' do
+      response = { 'code' => 124, 'message' => 'Invalid access token.' }
+      expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::AuthenticationError)
+    end
+
+    it 'raises Zoom::Error if error is present and code >= 300' do
+      response = { 'code' => 400, 'message' => 'lol error' }
       expect { Utils.raise_if_error!(response) }.to raise_error(Zoom::Error)
     end
 
@@ -26,14 +31,14 @@ xdescribe Zoom::Utils do
     end
   end
 
-  xdescribe '#extract_options!' do
+  describe '#extract_options!' do
     it 'converts array to hash options' do
       args = [{ foo: 'foo' }, { bar: 'bar' }, { zemba: 'zemba' }]
       expect(Utils.extract_options!(args)).to be_kind_of(Hash)
     end
   end
 
-  xdescribe '#process_datetime_params' do
+  describe '#process_datetime_params' do
     it 'converts the Time objects to formatted strings' do
       args = {
         foo: 'foo',


### PR DESCRIPTION
Sadly the authentication error doesn't follow the error code spec https://marketplace.zoom.us/docs/api-reference/error-definitions

The returned hash is: 

```
=> {"code"=>124, "message"=>"Invalid access token."}
```

I refactored the code to take this into account and re enabled the spec for this part of the code