### PR TITLE
Fix uninitialized constant SimpleDelegator

### DIFF
--- a/lib/zoom/params.rb
+++ b/lib/zoom/params.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'delegate'
 
 module Zoom
   class Params < SimpleDelegator


### PR DESCRIPTION
Apparently, Ruby 2.7 requires that we require this library explicitly.
Although, it works in irb in Ruby 2.7.
Ruby 2.6 works without it.
Based on a PR I found for another project, it seems this problem also existed
in Ruby 2.2. So who knows.

That PR is here: https://github.com/jnunemaker/httparty/pull/532