### PR TITLE
Add expires_in/expires_at to OAuth client

### DIFF
--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -3,7 +3,7 @@
 module Zoom
   class Client
     class OAuth < Zoom::Client
-      attr_reader :auth_token, :access_token, :refresh_token
+      attr_reader :auth_token, :access_token, :refresh_token, :expires_in, :expires_at
 
       # Auth_token is sent in the header
       # (auth_code, auth_token, redirect_uri) -> oauth API
@@ -45,6 +45,8 @@ module Zoom
         if response.is_a?(Hash) && !response.key?(:error)
           @access_token = response["access_token"]
           @refresh_token = response["refresh_token"]
+          @expires_in = response["expires_in"]
+          @expires_at = @expires_in ? (Time.now + @expires_in).to_i : nil
         end
       end
     end

--- a/spec/lib/zoom/client_spec.rb
+++ b/spec/lib/zoom/client_spec.rb
@@ -104,11 +104,13 @@ describe Zoom::Client do
                     headers: { 'Content-Type' => 'application/json' })
       end
 
-      it 'sets the refresh_token and access_token' do
+      it 'sets the refresh_token, access_token, expires_in and expires_at' do
         expected_values = JSON.parse(json_response('token', 'access_token'))
         zc.auth
         expect(zc.access_token).to eq(expected_values['access_token'])
         expect(zc.refresh_token).to eq(expected_values['refresh_token'])
+        expect(zc.expires_in).to eq(expected_values['expires_in'])
+        expect(zc.expires_at).to eq((Time.now + expected_values['expires_in']).to_i)
       end
     end
   end


### PR DESCRIPTION
Added `expires_in`, `expires_at` attributes to `Zoom::Client::OAuth`.
expires_in is included in the Zoom API response,
expires_at is a common attribute for OAuth libraries, and I think it's useful to have it.
