### PR TITLE
No need to require auth args if auth_token is included

### DIFF
--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -15,7 +15,7 @@ module Zoom
       def initialize(config)
         Zoom::Params.new(config).permit(:auth_token, :auth_code, :redirect_uri, :access_token, :refresh_token, :timeout)
         Zoom::Params.new(config).require_one_of(:access_token, :refresh_token, :auth_token)
-        if (config.keys & [:auth_token, :auth_code, :redirect_uri]).any?
+        if (config.keys & [:auth_code, :redirect_uri]).any?
           Zoom::Params.new(config).require(:auth_token, :auth_code, :redirect_uri)
         end
 

--- a/spec/lib/zoom/client_spec.rb
+++ b/spec/lib/zoom/client_spec.rb
@@ -69,10 +69,6 @@ describe Zoom::Client do
     end
 
     it 'raises an error if there is no complete auth token, auth code and redirect_uri' do
-      expect { Zoom::Client::OAuth.new(auth_token: 'xxx', timeout: 30) }.to raise_error(Zoom::ParameterMissing)
-    end
-
-    it 'raises an error if there is no complete auth token, auth code and redirect_uri' do
       expect { Zoom::Client::OAuth.new(auth_token: 'xxx', auth_code: 'xxx', redirect_uri: 'xxx') }.not_to raise_error(Zoom::ParameterMissing)
     end
 


### PR DESCRIPTION
Just a quick note, not sure if you want to include it but if you try and instantiate a client with a refresh token then there will be an error as was mentioned before, which may cause confusion.