### PR TITLE
OAuth class sets default value for the auth_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,19 +40,21 @@ https://zoom.us/oauth/authorize?response_type=code&client_id=7lstjKqdwjett_kwjwD
 
 Which will result in a redirect to your app with code in the url params
 
-then use this code to get an access token and a refresh token, the auth token is base64(client_id:client_secret).
+then use this code to get an access token and a refresh token.
+
+You can optionally pass in the auth token, it will default to base64(Zoom.configuration.api_key:Zoom.configuration.api_secret).
 
 ```ruby
 require 'zoom_rb'
 
-client = Zoom::Client::OAuth.new(auth_token: auth_token, auth_code: auth_code, timeout: 15).auth
+client = Zoom::Client::OAuth.new(auth_code: auth_code, redirect_uri: redirect_uri, timeout: 15).auth
 
 zoom_client = Zoom::Client::OAuth.new(access_token: 'xxx', timeout: 15)
 ```
 
 You can also make a call to refresh with auth using an auth_token and a refresh_token
 ```ruby
-client = Zoom::Client::OAuth.new(auth_token: auth_token, refresh_token: refresh_token).auth
+client = Zoom::Client::OAuth.new(refresh_token: refresh_token).auth
 
 zoom_client = Zoom::Client::OAuth.new(access_token: 'xxx', timeout: 15)
 ```

--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -8,11 +8,13 @@ module Zoom
       # Auth_token is sent in the header
       # (auth_code, auth_token, redirect_uri) -> oauth API
       # Returns (access_token, refresh_token)
+      # auth_token is optional, it will be set to base64(apiKey:apiSecret) by default
       #
       # (auth_token, refresh_token) -> oauth refresh API
       # Returns (access_token, refresh_token)
       #
       def initialize(config)
+        config[:auth_token] ||= Base64.strict_encode64("#{Zoom.configuration.api_key}:#{Zoom.configuration.api_secret}")
         Zoom::Params.new(config).permit(:auth_token, :auth_code, :redirect_uri, :access_token, :refresh_token, :timeout)
         Zoom::Params.new(config).require_one_of(:access_token, :refresh_token, :auth_token)
         if (config.keys & [:auth_code, :redirect_uri]).any?


### PR DESCRIPTION
This is just an idea I had. Not sure if there was a reason for not doing this. Instead of passing in the auth token, initialize can set the value since it has access to the config values.

Also update readme to reflect change and include `redirect_url` in the oAuth example.