### PR TITLE
Add host_video, meeting_authentication, on_demand, autorecording to possible settings

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -5,10 +5,15 @@ module Zoom
     module Webinar
       RECURRENCE_KEYS = %i[type repeat_interval weekly_days monthly_day monthly_week
                            monthly_week_day end_times end_date_time].freeze
-      SETTINGS_KEYS = %i[panelists_video practice_session hd_video approval_type
+      SETTINGS_KEYS = %i[host_video panelists_video practice_session hd_video approval_type
                          registration_type audio auto_recording enforce_login
                          enforce_login_domains alternative_hosts close_registration
-                         show_share_button allow_multiple_devices registrants_confirmation_email].freeze
+                         show_share_button allow_multiple_devices on_demand
+                         request_permission_to_unmute_participants global_dial_in_countries
+                         contact_name contact_email registrants_restrict_number
+                         post_webinar_survey survey_url registrants_email_notification
+                         meeting_authentication authentication_option
+                         authentication_domains registrants_confirmation_email question_answer].freeze
       def webinar_list(*args)
         params = Zoom::Params.new(Utils.extract_options!(args))
         params.require(:host_id).permit(:page_size, :page_number)


### PR DESCRIPTION
Hi,

This PR adds host_video, meeting_authentication, on_demand and autorecording to the list os permitted settings when creating a webinar.

Thanks.