### PR TITLE
Adds possibility to get meeting invitation by :meeting_id

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -97,6 +97,16 @@ module Zoom
         options.require(%i[meeting_id stream_url stream_key]).permit(%i[page_url])
         Utils.parse_response self.class.patch("/meetings/#{options[:meeting_id]}/livestream", body: options.except(:meeting_id), headers: request_headers)
       end
+
+      def meeting_invitation(*args)
+        options = Zoom::Params.new(Utils.extract_options!(args))
+        options.require(%i[meeting_id])
+
+        Utils.parse_response(
+          self.class.get("/meetings/#{options[:meeting_id]}/invitation",
+                         headers: request_headers)
+        )
+      end
     end
   end
 end

--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -100,7 +100,7 @@ module Zoom
 
       def meeting_invitation(*args)
         options = Zoom::Params.new(Utils.extract_options!(args))
-        options.require(%i[meeting_id])
+        options.require(:meeting_id)
 
         Utils.parse_response(
           self.class.get("/meetings/#{options[:meeting_id]}/invitation",

--- a/spec/fixtures/meeting/invitation.json
+++ b/spec/fixtures/meeting/invitation.json
@@ -1,0 +1,3 @@
+{
+    "invitation": "Team Member is inviting you to a scheduled Zoom meeting.\r\n\r\nTopic: Test meeting\r\nTime: Sep 17, 2020 03:49 PM Kiev\r\n\r\nJoin Zoom Meeting\r\nhttps://zoom.us/j/9451234446749?pwd=K3AwTGtdUVdqSnNVWnd6MaZxZnZEdz09\r\n\r\nMeeting ID: 943 1234 6721\r\nPasscode: DgA4yb\r\n\r\n"
+}

--- a/spec/lib/zoom/actions/meeting/invitation_spec.rb
+++ b/spec/lib/zoom/actions/meeting/invitation_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Zoom::Actions::Meeting do
+  subject(:meeting_invitation) { zoom_client.meeting_invitation(args) }
+
+  let(:args) { { meeting_id: 91538056781 } }
+
+  describe '#meeting_invitation action' do
+    before do
+      stub_request(
+        :get, zoom_url("/meetings/#{args[:meeting_id]}/invitation")
+      ).to_return(
+        status: 200,
+        body: json_response('meeting', 'invitation'),
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    context 'without :meeting_id parameter provided' do
+      let(:args) { {} }
+
+      it "requires a 'meeting_id' argument" do
+        expect { meeting_invitation }.to(
+          raise_error(Zoom::ParameterMissing, %i[meeting_id].to_s)
+        )
+      end
+    end
+
+    context 'when meeting_id parameter provided' do
+      let(:invitation) do
+        "Team Member is inviting you to a scheduled Zoom meeting.\r\n\r\n"\
+        "Topic: Test meeting\r\nTime: Sep 17, 2020 03:49 PM Kiev\r\n\r\n"\
+        "Join Zoom Meeting\r\nhttps://zoom.us/j/9451234446749?pwd=K3AwTGtdUVdqSnNVWnd6MaZxZnZEdz09\r\n\r\n"\
+        "Meeting ID: 943 1234 6721\r\nPasscode: DgA4yb\r\n\r\n"
+      end
+
+      it 'returns a hash' do
+        expect(meeting_invitation).to be_kind_of(Hash)
+      end
+
+      it 'returns id and attributes' do
+        expect(meeting_invitation['invitation']).to eq(invitation)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides endpoint for possibility to get a meeting invitation.
Link to the Zoom API documentation: https://marketplace.zoom.us/docs/api-reference/zoom-api/meetings/meetinginvitation