### PR TITLE
Using configuration credentials instead of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ require 'zoom_rb'
 
 auth = Zoom::Client::OAuth.new(auth_code: auth_code, redirect_uri: redirect_uri, timeout: 15).auth
 
-zoom_client = Zoom::Client::OAuth.new(access_token: 'xxx', timeout: 15)
+zoom_client = Zoom::Client::OAuth.new(access_token: auth['access_token'], timeout: 15)
 ```
 
 You can also make a call to refresh with auth using an auth_token and a refresh_token

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ https://zoom.us/oauth/authorize?response_type=code&client_id=7lstjKqdwjett_kwjwD
 
 Which will result in a redirect to your app with code in the url params
 
-then use this code to get an access token and a refresh token, the auth token is base64(client_id:client_secret).
+then use this code to get an access token and a refresh token.
 
 ```ruby
 require 'zoom_rb'
 
-client = Zoom::Client::OAuth.new(auth_token: auth_token, auth_code: auth_code, timeout: 15).auth
+auth = Zoom::Client::OAuth.new(auth_code: auth_code, redirect_uri: redirect_uri, timeout: 15).auth
 
 zoom_client = Zoom::Client::OAuth.new(access_token: 'xxx', timeout: 15)
 ```

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -46,7 +46,7 @@ module Zoom
     end
 
     def auth_token
-      Base64.encode64("#{ENV['ZOOM_APP_CLIENT_ID']}:#{ENV['ZOOM_APP_SECRET']}").delete("\n")
+      Base64.encode64("#{configuration.api_key}:#{configuration.api_secret}").delete("\n")
     end
   end
 end

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -46,7 +46,7 @@ module Zoom
     end
 
     def auth_token
-      Base64.encode64("#{configuration.api_key}:#{configuration.api_secret}").delete("\n")
+      Base64.encode64("#{Zoom.configuration.api_key}:#{Zoom.configuration.api_secret}").delete("\n")
     end
   end
 end

--- a/spec/lib/zoom/client_spec.rb
+++ b/spec/lib/zoom/client_spec.rb
@@ -93,6 +93,12 @@ describe Zoom::Client do
       let(:args) { { auth_code: 'xxx', redirect_uri: 'http://localhost:3000' } }
 
       before :each do
+        Zoom.configure do |config|
+          config.api_key = 'xxx'
+          config.api_secret = 'xxx'
+          config.timeout = 20
+        end
+
         stub_request(
           :post,
           zoom_auth_url('oauth/token')
@@ -107,6 +113,10 @@ describe Zoom::Client do
         expect(zc.refresh_token).to eq(expected_values['refresh_token'])
         expect(zc.expires_in).to eq(expected_values['expires_in'])
         expect(zc.expires_at).to eq((Time.now + expected_values['expires_in']).to_i)
+      end
+
+      it 'has the basic auth authorization header' do
+        expect(zc.oauth_request_headers['Authorization']).to eq("Basic eHh4Onh4eA==")
       end
     end
   end


### PR DESCRIPTION
We're already storing the Zoom app credentials in the client configuration. The changes here use the configuration credentials to build the authorization header auth token instead of loading it from hard-coded environment variables

Also updated the README to remove some older usage docs.