### PR TITLE
Add webinar recording settings and specs

### DIFF
--- a/lib/zoom/actions/recording.rb
+++ b/lib/zoom/actions/recording.rb
@@ -3,6 +3,10 @@
 module Zoom
   module Actions
     module Recording
+      RECORDING_SETTINGS_KEYS = %i[share_recording recording_authentication
+                                   authentication_option authentication_domains viewer_download password
+                                   on_demand approval_type send_email_to_host show_social_share_buttons].freeze
+
       def recording_list(*args)
         options = Zoom::Params.new(Utils.extract_options!(args))
         options.require(:user_id)
@@ -13,7 +17,19 @@ module Zoom
       def meeting_recording_get(*args)
         options = Zoom::Params.new(Utils.extract_options!(args))
         options.require(:meeting_id)
-        Utils.parse_response self.class.get("/meetings/#{options[:meeting_id]}/recordings", query: options.except(:meeting_id), headers: request_headers)
+        Utils.parse_response self.class.get("/meetings/#{options[:meeting_id]}/recordings/settings", query: options.except(:meeting_id), headers: request_headers)
+      end
+
+      def meeting_recording_settings_get(*args)
+        options = Zoom::Params.new(Utils.extract_options!(args))
+        options.require(:meeting_id)
+        Utils.parse_response self.class.get("/meetings/#{options[:meeting_id]}/recordings/settings", query: options.except(:meeting_id), headers: request_headers)
+      end
+
+      def meeting_recording_settings_update(*args)
+        options = Zoom::Params.new(Utils.extract_options!(args))
+        options.require(:meeting_id).permit(RECORDING_SETTINGS_KEYS)
+        Utils.parse_response self.class.patch("/meetings/#{options[:meeting_id]}/recordings/settings", body: options.except(:meeting_id).to_json, headers: request_headers)
       end
 
       def meeting_recording_file_delete(*args)

--- a/spec/fixtures/recording/settings/get.json
+++ b/spec/fixtures/recording/settings/get.json
@@ -1,0 +1,7 @@
+{
+  "on_demand": false,
+  "password": "",
+  "recording_authentication": false,
+  "share_recording": "publicly",
+  "viewer_download": false
+}

--- a/spec/lib/zoom/actions/recording/settings/get_spec.rb
+++ b/spec/lib/zoom/actions/recording/settings/get_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Zoom::Actions::Recording do
+  let(:zc) { zoom_client }
+  let(:args) { { meeting_id: 91538056781 } }
+
+  describe '#meeting_recordings_settings_get action' do
+    before :each do
+      stub_request(
+        :get,
+        zoom_url("/meetings/#{args[:meeting_id]}/recordings/settings")
+      ).to_return(
+        status: 200,
+        body: json_response('recording', 'settings', 'get'),
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    it "requires a 'meeting_id' argument" do
+      expect {
+        zc.meeting_recording_settings_get(filter_key(args, :meeting_id))
+      }.to raise_error(Zoom::ParameterMissing)
+    end
+
+    it 'returns a hash' do
+      expect(zc.meeting_recording_settings_get(args)).to be_kind_of(Hash)
+    end
+
+    it 'returns id and attributes' do
+      res = zc.meeting_recording_settings_get(args)
+
+      expect(res['on_demand']).to eq(false)
+      expect(res['password']).to eq('')
+      expect(res['recording_authentication']).to eq(false)
+      expect(res['share_recording']).to eq('publicly')
+      expect(res['viewer_download']).to eq(false)
+    end
+
+  end
+end

--- a/spec/lib/zoom/actions/recording/settings/update_spec.rb
+++ b/spec/lib/zoom/actions/recording/settings/update_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Zoom::Actions::Recording do
+  let(:zc) { zoom_client }
+  let(:args) { { meeting_id: 91538056781, on_demand: false } }
+
+  describe '#meeting_recordings_settings_update action' do
+    context 'with 204 response' do
+      before :each do
+        stub_request(
+          :patch,
+          zoom_url("/meetings/#{args[:meeting_id]}/recordings/settings")
+        ).to_return(
+          status: 204,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it "requires a 'meeting_id' argument" do
+        expect {
+          zc.meeting_recording_settings_update(filter_key(args, :meeting_id))
+        }.to raise_error(Zoom::ParameterMissing, [:meeting_id].to_s)
+      end
+
+      it 'returns a status code' do
+        expect(zc.meeting_recording_settings_update(args)).to eq 204
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

This PR adds support for these two endpoints:

https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingsettingupdate
https://marketplace.zoom.us/docs/api-reference/zoom-api/cloud-recording/recordingsettingsupdate

Thanks,
Gonzalo.