### PR TITLE
JSON transform to create user assistant

### DIFF
--- a/lib/zoom/actions/user.rb
+++ b/lib/zoom/actions/user.rb
@@ -46,7 +46,7 @@ module Zoom
       def user_assistants_create(*args)
         params = Zoom::Params.new(Utils.extract_options!(args))
         params.require(:user_id).permit(:assistants)
-        Utils.parse_response self.class.post("/users/#{params[:user_id]}/assistants", body: params.except(:user_id), headers: request_headers)
+        Utils.parse_response self.class.post("/users/#{params[:user_id]}/assistants", body: params.except(:user_id).to_json, headers: request_headers)
       end
 
       def user_assistants_delete_all(*args)


### PR DESCRIPTION
Some of posts requests needs to use `to_json` transform on body to avoid the message `Request Body should be a valid JSON object.`

This is a fix for `user_assistants_create` method.