### PR TITLE
Update Readme with correct require statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Or install it yourself as:
 The Zoom API uses OAuth or JWT to [Authenticate](https://marketplace.zoom.us/docs/api-reference/Authentication) API request. By defaut, a JWT client will be used.
 
 ```ruby
-require 'zoom_rb'
+require 'zoom'
 
 Zoom.configure do |c|
   c.api_key = 'xxx'
@@ -43,7 +43,7 @@ Which will result in a redirect to your app with code in the url params
 then use this code to get an access token and a refresh token.
 
 ```ruby
-require 'zoom_rb'
+require 'zoom'
 
 auth = Zoom::Client::OAuth.new(auth_code: auth_code, redirect_uri: redirect_uri, timeout: 15).auth
 


### PR DESCRIPTION
```ruby
~/hardbap
11:07 $ gem list | ag zoom
zoom_rb (0.10.0)
~/hardbap
11:07 $ irb
irb(main):001:0> require 'zoom_rb'
Traceback (most recent call last):
LoadError (cannot load such file -- zoom_rb)
irb(main):002:0> require 'zoom'
=> true
```