### PR TITLE
Revoking an Access Token

### DIFF
--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -23,6 +23,13 @@ module Zoom
         response = self.class.post("/oauth/data/compliance", body: options.to_json, headers: oauth_request_headers, base_uri: 'https://zoom.us/')
         Utils.parse_response response
       end
+
+      def revoke_tokens(*args)
+        options = Zoom::Params.new(Utils.extract_options!(args))
+        options.require(%i[access_token])
+        response = self.class.post("/oauth/revoke?token=#{options[:access_token]}", headers: oauth_request_headers, base_uri: 'https://zoom.us/')
+        Utils.parse_response(response)
+      end
     end
   end
 end

--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -39,6 +39,12 @@ module Zoom
         response
       end
 
+      def revoke
+        response = revoke_tokens(access_token: @access_token)
+        set_tokens(response)
+        response
+      end
+
       private
 
       def set_tokens(response)


### PR DESCRIPTION
To revoke a users access token, make a POST request to `https://zoom.us/oauth/revoke`
https://marketplace.zoom.us/docs/guides/auth/oauth#revoking


Usage
```
zoom_client = Zoom::Client::OAuth.new(access_token: 'xxx')
zoom_client.revoke
```