### PR TITLE
Fix broken OAuth requests by defining request_headers on each client

### DIFF
--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -32,22 +32,6 @@ module Zoom
         'Content-Type' => 'application/json',
       }
     end
-
-    def oauth_request_headers
-      {
-        'Authorization' => "Basic #{auth_token}"
-      }.merge(headers)
-    end
-
-    def request_headers
-      {
-        'Authorization' => "Bearer #{access_token}"
-      }.merge(headers)
-    end
-
-    def auth_token
-      Base64.encode64("#{Zoom.configuration.api_key}:#{Zoom.configuration.api_secret}").delete("\n")
-    end
   end
 end
 

--- a/lib/zoom/clients/jwt.rb
+++ b/lib/zoom/clients/jwt.rb
@@ -4,7 +4,6 @@ require 'jwt'
 module Zoom
   class Client
     class JWT < Zoom::Client
-
       def initialize(config)
         Zoom::Params.new(config).require(:api_key, :api_secret)
         config.each { |k, v| instance_variable_set("@#{k}", v) }
@@ -15,6 +14,11 @@ module Zoom
         ::JWT.encode({ iss: @api_key, exp: Time.now.to_i + @timeout }, @api_secret, 'HS256', { typ: 'JWT' })
       end
 
+      def request_headers
+        {
+          'Authorization' => "Bearer #{access_token}"
+        }.merge(headers)
+      end
     end
   end
 end

--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -23,6 +23,16 @@ module Zoom
         self.class.default_timeout(@timeout || 20)
       end
 
+      def auth_token
+        Base64.encode64("#{Zoom.configuration.api_key}:#{Zoom.configuration.api_secret}").delete("\n")
+      end
+
+      def request_headers
+        {
+          'Authorization' => "Basic #{auth_token}"
+        }.merge(headers)
+      end
+
       def auth
         refresh_token ? refresh : oauth
       end

--- a/lib/zoom/clients/oauth.rb
+++ b/lib/zoom/clients/oauth.rb
@@ -29,7 +29,7 @@ module Zoom
 
       def request_headers
         {
-          'Authorization' => "Basic #{auth_token}"
+          'Authorization' => access_token ? "Bearer #{access_token}" : "Basic #{auth_token}"
         }.merge(headers)
       end
 

--- a/spec/lib/zoom/client_spec.rb
+++ b/spec/lib/zoom/client_spec.rb
@@ -116,7 +116,7 @@ describe Zoom::Client do
       end
 
       it 'has the basic auth authorization header' do
-        expect(zc.oauth_request_headers['Authorization']).to eq("Basic eHh4Onh4eA==")
+        expect(zc.request_headers['Authorization']).to eq("Basic eHh4Onh4eA==")
       end
     end
   end


### PR DESCRIPTION
Looks like `oauth_request_headers` were left unused after the recent migration which led to OAuth requests failing with `{"reason"=>"Internal Error", "error"=>"invalid_request"}`.

Previously, `oauth_request_headers` were passed directly to `Zoom::Actions::Token` requests, as seen here: https://github.com/hintmedia/zoom_rb/blob/49ed270cccf77ed20a3da6555a1d6bcecd3a75f9/lib/zoom/actions/token.rb#L9

But since the last change, headers are passed directly from the client instance, which led to the OAuth client sending requests with the `access_token` instead of the `auth_token`. https://github.com/hintmedia/zoom_rb/blob/6eb9d6a94aa14f0ad605fe15c29f0ac8f8343989/lib/zoom/actions.rb#L19

This change resolves that issue.