### PR TITLE
Fix OAuth bug

### DIFF
--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -7,20 +7,20 @@ module Zoom
 
       post 'access_tokens',
         '/oauth/token?grant_type=authorization_code&code=:auth_code&redirect_uri=:redirect_uri',
-        base_uri: 'https://zoom.us/'
+        oauth: true
 
       post 'refresh_tokens',
         '/oauth/token?grant_type=refresh_token&refresh_token=:refresh_token',
-        base_uri: 'https://zoom.us/'
+        oauth: true
 
       post 'data_compliance', '/oauth/data/compliance',
-        base_uri: 'https://zoom.us/',
+        oauth: true,
         require: %i[
           client_id user_id account_id deauthorization_event_received compliance_completed
         ]
 
       post 'revoke_tokens', '/oauth/revoke?token=:access_token',
-        base_uri: 'https://zoom.us/'
+        oauth: true
     end
   end
 end

--- a/spec/lib/zoom/actions_spec.rb
+++ b/spec/lib/zoom/actions_spec.rb
@@ -7,7 +7,7 @@ describe Zoom::Actions do
   let(:path) { '/:id/foo/:bar' }
   let(:path_keys) { [:id, :bar] }
   let(:params) { { id: 100, bar: 'baz' } }
-  let(:base_uri) { 'https://example.com' }
+  let(:oauth) { false }
   let(:parsed_path) { '/100/foo/baz' }
 
   describe 'self.extract_path_keys' do
@@ -23,14 +23,9 @@ describe Zoom::Actions do
   end
 
   describe 'self.make_request' do
-    subject { described_class.make_request(client, method, parsed_path, params, base_uri) }
+    subject { described_class.make_request(client, method, parsed_path, params, request_options) }
 
-    let(:request_options) {
-      {
-        headers: client.request_headers,
-        base_uri: base_uri
-      }
-    }
+    let(:request_options) { Zoom::Actions.determine_request_options(client, oauth) }
 
     context 'when get' do
       let(:method) { :get }
@@ -76,6 +71,32 @@ describe Zoom::Actions do
       let(:method) { :delete }
 
       it 'calls delete method on client with delete request_options' do
+        expect(client.class).to receive(method).with(parsed_path, **request_options)
+        subject
+      end
+    end
+
+    context 'when oauth' do
+      let(:method) { :get }
+      let(:oauth) { true }
+
+      it 'passes oauth request options' do
+        request_options[:query] = params
+        expect(request_options[:headers]).to eq(client.oauth_request_headers)
+        expect(request_options[:base_uri]).to eq('https://zoom.us/')
+        expect(client.class).to receive(method).with(parsed_path, **request_options)
+        subject
+      end
+    end
+
+    context 'when not oauth' do
+      let(:method) { :get }
+      let(:oauth) { false }
+
+      it 'passes standard request options' do
+        request_options[:query] = params
+        expect(request_options[:headers]).to eq(client.request_headers)
+        expect(request_options[:base_uri]).to be_nil
         expect(client.class).to receive(method).with(parsed_path, **request_options)
         subject
       end


### PR DESCRIPTION
I made an error in my refactor and failed to change the headers for
OAuth requests. This will replace the "base_uri" option with a flag,
"oauth" which will automatically set the base_uri and the headers for
OAuth requests. The only requests that use these are Zoom::Actions::Token.