### PR TITLE
Use correct "question_and_answer" spec

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -6,16 +6,26 @@ module Zoom
       extend Zoom::Actions
 
       RECURRENCE_KEYS = %i[type repeat_interval weekly_days monthly_day monthly_week
-                           monthly_week_day end_times end_date_time].freeze
-      SETTINGS_KEYS = %i[host_video panelists_video practice_session hd_video approval_type
-                         registration_type audio auto_recording enforce_login
-                         enforce_login_domains alternative_hosts close_registration
-                         show_share_button allow_multiple_devices on_demand
-                         request_permission_to_unmute_participants global_dial_in_countries
-                         contact_name contact_email registrants_restrict_number
-                         post_webinar_survey survey_url registrants_email_notification
-                         meeting_authentication authentication_option
-                         authentication_domains registrants_confirmation_email question_answer].freeze
+                            monthly_week_day end_times end_date_time].freeze
+      SETTINGS_KEYS = [
+                        %i[
+                          host_video panelists_video practice_session hd_video approval_type
+                          registration_type audio auto_recording enforce_login
+                          enforce_login_domains alternative_hosts close_registration
+                          show_share_button allow_multiple_devices on_demand
+                          request_permission_to_unmute_participants global_dial_in_countries
+                          contact_name contact_email registrants_restrict_number
+                          post_webinar_survey survey_url registrants_email_notification
+                          meeting_authentication authentication_option
+                          authentication_domains registrants_confirmation_email
+                        ].freeze,
+                        {
+                          question_and_answer: %i[
+                            allow_anonymous_questions, answer_questions, attendees_can_comment,
+                            attendees_can_upvote, enable
+                          ]
+                        }
+                      ]
 
       get 'webinar_list', '/users/:host_id/webinars',
         permit: %i[page_size page_number]

--- a/spec/fixtures/webinar/create.json
+++ b/spec/fixtures/webinar/create.json
@@ -24,6 +24,12 @@
         "allow_multiple_devices": true,
         "practice_session": false,
         "hd_video": false,
-        "question_answer": true
+        "question_and_answer": {
+            "allow_anonymous_question": true,
+            "answer_questions": "all",
+            "attendees_can_comment": true,
+            "attendees_can_upvote": true,
+            "enable": true
+        }
     }
 }

--- a/spec/fixtures/webinar/create.json
+++ b/spec/fixtures/webinar/create.json
@@ -25,7 +25,7 @@
         "practice_session": false,
         "hd_video": false,
         "question_and_answer": {
-            "allow_anonymous_question": true,
+            "allow_anonymous_questions": true,
             "answer_questions": "all",
             "attendees_can_comment": true,
             "attendees_can_upvote": true,


### PR DESCRIPTION
A mistake was made when these keys were originally added. This is not a
"question_answer" boolean but rather a "question_and_answer" hash containing
multiple other variables.

Resolves #393