### PR TITLE
KMP-3232: ServerToServerOAuth client

### DIFF
--- a/lib/zoom/actions/token.rb
+++ b/lib/zoom/actions/token.rb
@@ -12,6 +12,11 @@ module Zoom
         permit: :code_verifier,
         args_to_params: { auth_code: :code }
 
+      post 'access_tokens_account_credentials',
+        '/oauth/token?grant_type=account_credentials',
+        oauth: true,
+        require: :account_id
+
       post 'refresh_tokens',
         '/oauth/token',
         oauth: true,

--- a/lib/zoom/client.rb
+++ b/lib/zoom/client.rb
@@ -59,3 +59,4 @@ end
 
 require 'zoom/clients/jwt'
 require 'zoom/clients/oauth'
+require 'zoom/clients/server_to_server_oauth'

--- a/lib/zoom/clients/server_to_server_oauth.rb
+++ b/lib/zoom/clients/server_to_server_oauth.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Zoom
+  class Client
+    class ServerToServerOAuth < Zoom::Client
+      attr_reader :access_token, :expires_in, :expires_at
+
+      def initialize(config)
+        Zoom::Params.new(config).permit(%i[access_token account_id client_id client_secret timeout])
+        Zoom::Params.new(config).require_one_of(%i[access_token account_id client_id client_secret])
+
+        config.each { |k, v| instance_variable_set("@#{k}", v) }
+        self.class.default_timeout(@timeout || 20)
+      end
+
+      def auth
+        response = access_tokens_account_credentials(account_id: @account_id)
+        set_tokens(response)
+        response
+      end
+
+      def auth_token
+        Base64.urlsafe_encode64("#{@client_id}:#{@client_secret}")
+      end
+
+      private
+
+      def set_tokens(response)
+        if response.is_a?(Hash) && !response.key?(:error)
+          @access_token = response["access_token"]
+          @expires_in = response["expires_in"]
+          @expires_at = @expires_in ? (Time.now + @expires_in).to_i : nil
+        end
+      end
+    end
+  end
+end

--- a/lib/zoom/clients/server_to_server_oauth.rb
+++ b/lib/zoom/clients/server_to_server_oauth.rb
@@ -7,7 +7,7 @@ module Zoom
 
       def initialize(config)
         Zoom::Params.new(config).permit(%i[access_token account_id client_id client_secret timeout])
-        Zoom::Params.new(config).require_one_of(%i[access_token account_id client_id client_secret])
+        Zoom::Params.new(config).require_one_of(%i[access_token account_id])
 
         config.each { |k, v| instance_variable_set("@#{k}", v) }
         self.class.default_timeout(@timeout || 20)
@@ -20,7 +20,9 @@ module Zoom
       end
 
       def auth_token
-        Base64.urlsafe_encode64("#{@client_id}:#{@client_secret}")
+        return Base64.urlsafe_encode64("#{@client_id}:#{@client_secret}") if @client_id && @client_secret
+
+        Base64.urlsafe_encode64("#{Zoom.configuration.api_key}:#{Zoom.configuration.api_secret}")
       end
 
       private

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,10 @@ def oauth_client
   Zoom::Client::OAuth.new(auth_token: 'xxx', auth_code: 'xxx', redirect_uri: 'xxx', timeout: 15)
 end
 
+def server_to_server_oauth_client
+  Zoom::Client::ServerToServerOAuth.new(account_id: 'xxx', client_id: 'xxx', client_secret: 'xxx')
+end
+
 def zoom_client
   jwt_client
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,7 +46,7 @@ def oauth_client
 end
 
 def server_to_server_oauth_client
-  Zoom::Client::ServerToServerOAuth.new(account_id: 'xxx', client_id: 'xxx', client_secret: 'xxx')
+  Zoom::Client::ServerToServerOAuth.new(account_id: 'xxx')
 end
 
 def zoom_client


### PR DESCRIPTION
Now zoom_rb gem doesn't support ServerToServerOAuth. This PR adds ServerToServerOAuth class. For information view the page: https://marketplace.zoom.us/docs/guides/build/server-to-server-oauth-app/