### PR TITLE
Let webinars update API accepts language interpretation in settings

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -8,24 +8,28 @@ module Zoom
       RECURRENCE_KEYS = %i[type repeat_interval weekly_days monthly_day monthly_week
                             monthly_week_day end_times end_date_time].freeze
       SETTINGS_KEYS = [
-        %i[host_video panelists_video practice_session hd_video approval_type
-         registration_type audio auto_recording enforce_login
-         enforce_login_domains alternative_hosts close_registration
-         show_share_button allow_multiple_devices on_demand
-         request_permission_to_unmute_participants global_dial_in_countries
-         contact_name contact_email registrants_restrict_number
-         post_webinar_survey survey_url registrants_email_notification
-         meeting_authentication authentication_option
-         authentication_domains registrants_confirmation_email],
-        { language_interpretation: [
-          :enable,
-          interpreters: %i[email languages]
-        ],
-          question_and_answer: %i[
-            allow_anonymous_questions answer_questions attendees_can_comment
-            attendees_can_upvote enable
-          ] }
-      ].freeze
+                        %i[
+                            host_video panelists_video practice_session hd_video approval_type
+                            registration_type audio auto_recording enforce_login
+                            enforce_login_domains alternative_hosts close_registration
+                            show_share_button allow_multiple_devices on_demand
+                            request_permission_to_unmute_participants global_dial_in_countries
+                            contact_name contact_email registrants_restrict_number
+                            post_webinar_survey survey_url registrants_email_notification
+                            meeting_authentication authentication_option
+                            authentication_domains registrants_confirmation_email
+                        ],
+                        {
+                            language_interpretation: [
+                            :enable,
+                            interpreters: %i[email languages]
+                          ],
+                          question_and_answer: %i[
+                            allow_anonymous_questions answer_questions attendees_can_comment
+                            attendees_can_upvote enable
+                          ]
+                        }
+                      ].freeze
 
       get 'webinar_list', '/users/:host_id/webinars',
         permit: %i[page_size page_number]

--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -9,15 +9,15 @@ module Zoom
                             monthly_week_day end_times end_date_time].freeze
       SETTINGS_KEYS = [
                         %i[
-                            host_video panelists_video practice_session hd_video approval_type
-                            registration_type audio auto_recording enforce_login
-                            enforce_login_domains alternative_hosts close_registration
-                            show_share_button allow_multiple_devices on_demand
-                            request_permission_to_unmute_participants global_dial_in_countries
-                            contact_name contact_email registrants_restrict_number
-                            post_webinar_survey survey_url registrants_email_notification
-                            meeting_authentication authentication_option
-                            authentication_domains registrants_confirmation_email
+                          host_video panelists_video practice_session hd_video approval_type
+                          registration_type audio auto_recording enforce_login
+                          enforce_login_domains alternative_hosts close_registration
+                          show_share_button allow_multiple_devices on_demand
+                          request_permission_to_unmute_participants global_dial_in_countries
+                          contact_name contact_email registrants_restrict_number
+                          post_webinar_survey survey_url registrants_email_notification
+                          meeting_authentication authentication_option
+                          authentication_domains registrants_confirmation_email
                         ],
                         {
                             language_interpretation: [

--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -8,15 +8,15 @@ module Zoom
       RECURRENCE_KEYS = %i[type repeat_interval weekly_days monthly_day monthly_week
                             monthly_week_day end_times end_date_time].freeze
       SETTINGS_KEYS = [
-        :host_video, :panelists_video, :practice_session, :hd_video, :approval_type,
-        :registration_type, :audio, :auto_recording, :enforce_login,
-        :enforce_login_domains, :alternative_hosts, :close_registration,
-        :show_share_button, :allow_multiple_devices, :on_demand,
-        :request_permission_to_unmute_participants, :global_dial_in_countries,
-        :contact_name, :contact_email, :registrants_restrict_number,
-        :post_webinar_survey, :survey_url, :registrants_email_notification,
-        :meeting_authentication, :authentication_option,
-        :authentication_domains, :registrants_confirmation_email,
+        %i[host_video panelists_video practice_session hd_video approval_type
+         registration_type audio auto_recording enforce_login
+         enforce_login_domains alternative_hosts close_registration
+         show_share_button allow_multiple_devices on_demand
+         request_permission_to_unmute_participants global_dial_in_countries
+         contact_name contact_email registrants_restrict_number
+         post_webinar_survey survey_url registrants_email_notification
+         meeting_authentication authentication_option
+         authentication_domains registrants_confirmation_email],
         { language_interpretation: [
           :enable,
           interpreters: %i[email languages]

--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -8,24 +8,24 @@ module Zoom
       RECURRENCE_KEYS = %i[type repeat_interval weekly_days monthly_day monthly_week
                             monthly_week_day end_times end_date_time].freeze
       SETTINGS_KEYS = [
-                        %i[
-                          host_video panelists_video practice_session hd_video approval_type
-                          registration_type audio auto_recording enforce_login
-                          enforce_login_domains alternative_hosts close_registration
-                          show_share_button allow_multiple_devices on_demand
-                          request_permission_to_unmute_participants global_dial_in_countries
-                          contact_name contact_email registrants_restrict_number
-                          post_webinar_survey survey_url registrants_email_notification
-                          meeting_authentication authentication_option
-                          authentication_domains registrants_confirmation_email
-                        ].freeze,
-                        {
-                          question_and_answer: %i[
-                            allow_anonymous_questions, answer_questions, attendees_can_comment,
-                            attendees_can_upvote, enable
-                          ]
-                        }
-                      ]
+        :host_video, :panelists_video, :practice_session, :hd_video, :approval_type,
+        :registration_type, :audio, :auto_recording, :enforce_login,
+        :enforce_login_domains, :alternative_hosts, :close_registration,
+        :show_share_button, :allow_multiple_devices, :on_demand,
+        :request_permission_to_unmute_participants, :global_dial_in_countries,
+        :contact_name, :contact_email, :registrants_restrict_number,
+        :post_webinar_survey, :survey_url, :registrants_email_notification,
+        :meeting_authentication, :authentication_option,
+        :authentication_domains, :registrants_confirmation_email,
+        { language_interpretation: [
+          :enable,
+          interpreters: %i[email languages]
+        ],
+          question_and_answer: %i[
+            allow_anonymous_questions answer_questions attendees_can_comment
+            attendees_can_upvote enable
+          ] }
+      ].freeze
 
       get 'webinar_list', '/users/:host_id/webinars',
         permit: %i[page_size page_number]

--- a/lib/zoom/params.rb
+++ b/lib/zoom/params.rb
@@ -32,7 +32,7 @@ module Zoom
                            array << hash_filter(filter)
                          end
                        end
-      non_permitted_params = @parameters.keys - permitted_keys.flatten
+      non_permitted_params = parameters_keys - permitted_keys.flatten
       raise Zoom::ParameterNotPermitted, non_permitted_params.to_s unless non_permitted_params.empty?
     end
 
@@ -104,6 +104,14 @@ module Zoom
       value = @parameters[key]
       unless !value || values.include?(value)
         raise Zoom::ParameterValueNotPermitted, "#{key}: #{value}"
+      end
+    end
+
+    def parameters_keys
+      if @parameters.kind_of?(Array)
+        @parameters.map(&:keys).flatten.uniq
+      else
+        @parameters.keys
       end
     end
   end

--- a/spec/lib/zoom/params_spec.rb
+++ b/spec/lib/zoom/params_spec.rb
@@ -98,4 +98,22 @@ RSpec.describe Zoom::Params do
       expect { params.permit_value(:baz, values) }.to raise_error(Zoom::ParameterValueNotPermitted, "#{:baz.to_s}: #{:bang.to_s}")
     end
   end
+
+  describe '#parameters_keys' do
+    context 'when param is array ' do
+      let(:params) { Zoom::Params.new([{foo: :bar, baz: :bang}, {foo: :bar1, baz: :bang1}]) }
+  
+      it 'get each object keys and return unique of them' do
+        expect(params.parameters_keys).to eq([:foo, :baz])
+      end
+    end
+    
+    context 'when param is Hash ' do
+      let(:params) { Zoom::Params.new({foo: :bar, baz: :bang}) }
+  
+      it 'return hash keys' do
+        expect(params.parameters_keys).to eq([:foo, :baz])
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR will add a language interpretation option to webinars settings that will allow interpreters to be added on zoom.