### PR TITLE
Past webinars absentees

### DIFF
--- a/lib/zoom/actions/webinar.rb
+++ b/lib/zoom/actions/webinar.rb
@@ -77,6 +77,9 @@ module Zoom
       get 'webinar_poll_get', '/webinars/:webinar_id/polls/:poll_id'
 
       get 'webinar_panelist_list', '/webinars/:webinar_id/panelists'
+
+      get 'past_webinars_absentees', '/past_webinars/:webinar_uuid/absentees',
+        permit: %i[occurrence_id page_size next_page_token]
     end
   end
 end

--- a/spec/fixtures/webinar/past_webinars_absentees.json
+++ b/spec/fixtures/webinar/past_webinars_absentees.json
@@ -1,0 +1,37 @@
+{
+  "next_page_token": "w7587w4eiyfsudgf",
+  "page_count": 1,
+  "page_number": 1,
+  "page_size": 30,
+  "total_records": 20,
+  "registrants": [
+    {
+      "id": "9tboDiHUQAeOnbmudzWa5g",
+      "address": "1800 Amphibious Blvd.",
+      "city": "Mountain View",
+      "comments": "Looking forward to the discussion.",
+      "country": "US",
+      "custom_questions": [
+        {
+          "title": "What do you hope to learn from this?",
+          "value": "Look forward to learning how you come up with new recipes and what other services you offer."
+        }
+      ],
+      "email": "jchill@example.com",
+      "first_name": "Jill",
+      "industry": "Food",
+      "job_title": "Chef",
+      "last_name": "Chill",
+      "no_of_employees": "1-20",
+      "org": "Cooking Org",
+      "phone": "5550100",
+      "purchasing_time_frame": "1-3 months",
+      "role_in_purchase_process": "Influencer",
+      "state": "CA",
+      "status": "approved",
+      "zip": "94045",
+      "create_time": "2022-03-22T05:59:09Z",
+      "join_url": "https://example.com/j/11111"
+    }
+  ]
+}

--- a/spec/lib/zoom/actions/webinar/past_webinar_absentees_spec.rb
+++ b/spec/lib/zoom/actions/webinar/past_webinar_absentees_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe Zoom::Actions::Webinar do
+  let(:zc) { zoom_client }
+  let(:args) { { webinar_uuid: '123456789' } }
+
+    describe '#past_webinars_absentees' do
+    context 'with a valid response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/past_webinars/#{args[:webinar_uuid]}/absentees")
+        ).to_return(status: 200,
+                    body: json_response('webinar', 'past_webinars_absentees'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it "requires a 'uuid' argument" do
+        expect { zc.past_webinars_absentees(filter_key(args, :webinar_uuid)) }.to raise_error(Zoom::ParameterMissing, [:webinar_uuid].to_s)
+      end
+
+      it 'returns a webinar instance with registrants as an array' do
+        expect(zc.past_webinars_absentees(args)['registrants']).to be_kind_of(Array)
+      end
+    end
+
+    context 'with a 4xx response' do
+      before :each do
+        stub_request(
+          :get,
+          zoom_url("/past_webinars/#{args[:webinar_uuid]}/absentees")
+        ).to_return(status: 404,
+                    body: json_response('error', 'validation'),
+                    headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'raises Zoom::Error exception' do
+        expect { zc.past_webinars_absentees(args) }.to raise_error(Zoom::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added endpoint for past webinar absentees
https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#tag/Webinars/operation/webinarAbsentees