### PR TITLE
Inherit from Zoom::Error

### DIFF
--- a/lib/zoom/error.rb
+++ b/lib/zoom/error.rb
@@ -9,17 +9,17 @@ module Zoom
       super(msg)
     end
   end
-  class GatewayTimeout < StandardError; end
-  class NotImplemented < StandardError; end
-  class ParameterMissing < StandardError; end
-  class ParameterNotPermitted < StandardError; end
-  class ParameterValueNotPermitted < StandardError; end
-  class AuthenticationError < StandardError; end
-  class BadRequest < StandardError; end
-  class Unauthorized < StandardError; end
-  class Forbidden < StandardError; end
-  class NotFound < StandardError; end
-  class Conflict < StandardError; end
-  class TooManyRequests < StandardError; end
-  class InternalServerError < StandardError; end
+  class GatewayTimeout < Error; end
+  class NotImplemented < Error; end
+  class ParameterMissing < Error; end
+  class ParameterNotPermitted < Error; end
+  class ParameterValueNotPermitted < Error; end
+  class AuthenticationError < Error; end
+  class BadRequest < Error; end
+  class Unauthorized < Error; end
+  class Forbidden < Error; end
+  class NotFound < Error; end
+  class Conflict < Error; end
+  class TooManyRequests < Error; end
+  class InternalServerError < Error; end
 end

--- a/spec/lib/zoom/errors_spec.rb
+++ b/spec/lib/zoom/errors_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Zoom::Error do
+  let(:rescue?) { false }
+  subject do
+    begin
+      raise Zoom::ParameterMissing, "msg"
+    rescue Zoom::Error => error
+      if rescue?
+        true
+      else
+        raise error
+      end
+    end
+  end
+  it 'raises specific errors' do
+    expect { subject }.to raise_error(Zoom::ParameterMissing, "msg")
+  end
+
+  context 'with errors rescued' do
+    let(:rescue?) { true }
+    it 'descends from Zoom::Error' do
+      expect(subject).to be true
+    end
+  end
+end

--- a/spec/lib/zoom/errors_spec.rb
+++ b/spec/lib/zoom/errors_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Zoom::Error do
   let(:rescue?) { false }
+
   subject do
     begin
       raise Zoom::ParameterMissing, "msg"
@@ -15,12 +16,14 @@ RSpec.describe Zoom::Error do
       end
     end
   end
+
   it 'raises specific errors' do
     expect { subject }.to raise_error(Zoom::ParameterMissing, "msg")
   end
 
   context 'with errors rescued' do
     let(:rescue?) { true }
+
     it 'descends from Zoom::Error' do
       expect(subject).to be true
     end


### PR DESCRIPTION
In response to https://github.com/hintmedia/zoom_rb/pull/429#issuecomment-1204148701, need to inherit from `Zoom::Error` to maintain backwards compatibility.