### PR TITLE
Batch registrants

### DIFF
--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -44,6 +44,10 @@ module Zoom
           language occurrence_ids
         ]
 
+      # Register up to 30 registrants at once for a meeting that requires registration.
+      post 'batch_registrants', '/meetings/:meeting_id/batch_registrants',
+        permit: %i[registrants auto_approve registrants_confirmation_email]
+
       # Register for a meeting.
       patch 'meeting_registrant_questions', '/meeting/:meeting_id/registrants/questions'
 

--- a/lib/zoom/actions/meeting.rb
+++ b/lib/zoom/actions/meeting.rb
@@ -41,7 +41,7 @@ module Zoom
         permit: %i[
           last_name address city country zip state phone industry org job_title
           purchasing_time_frame role_in_purchase_process no_of_employees comments custom_questions
-          language occurrence_ids
+          language occurrence_ids auto_approve
         ]
 
       # Register up to 30 registrants at once for a meeting that requires registration.


### PR DESCRIPTION
 Register up to 30 registrants at once for a meeting that requires registration.